### PR TITLE
bump requests to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ oauth2client==4.1.2
 oauthlib==2.0.7
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
-requests==2.18.4
+requests==2.20.0
 requests-oauthlib==0.8.0
 rsa==3.4.2
 six==1.11.0


### PR DESCRIPTION
avoids security risks